### PR TITLE
feat: confirmar exclusão de hábito

### DIFF
--- a/script.js
+++ b/script.js
@@ -44,6 +44,9 @@ function renderHabitItem(habit) {
   deleteButton.className = "danger";
 
   deleteButton.addEventListener("click", () => {
+    const ok = confirm(`Excluir o hábito "${habit.name}"?`);
+    if (!ok) return;
+
     habits = habits.filter((item) => item.id !== habit.id);
     saveHabits();
     renderHabits();


### PR DESCRIPTION
## O que foi feito
- Adicionada confirmação antes de excluir um hábito.

## Por quê
- Evita exclusões acidentais e melhora a experiência do usuário.

## Como testei
- [x] Clicar em "Excluir" e cancelar (não remove)
- [x] Clicar em "Excluir" e confirmar (remove e persiste)
- [x] Recarregar a página e verificar que o hábito continua removido
