### PR TITLE
feat: impedir hábitos duplicados

### DIFF
--- a/script.js
+++ b/script.js
@@ -94,6 +94,16 @@ form.addEventListener("submit", (event) => {
   const habitName = input.value.trim();
   if (!habitName) return;
 
+  const normalized = habitName.toLowerCase();
+  const alreadyExists = habits.some(
+    (h) => h.name.trim().toLowerCase() === normalized
+  );
+
+  if (alreadyExists) {
+    alert("Esse hábito já existe na lista.");
+    return;
+  }
+
   habits.push({
     id: Date.now(),
     name: habitName,


### PR DESCRIPTION
## O que foi feito
- Impede adicionar hábitos duplicados (ignorando maiúsculas/minúsculas e espaços).

## Por quê
- Evita lista poluída por entradas repetidas.

## Como testei
- [x] Tentar adicionar o mesmo hábito com letras diferentes (ex: "Caminhar" e "caminhar")
- [x] Tentar adicionar com espaços extras (ex: "  caminhar  ")
- [x] Adicionar um hábito diferente (deve funcionar)
